### PR TITLE
fix: clean up EV metadata display in ImagePreview

### DIFF
--- a/src/Gallery/ImagePreview.tsx
+++ b/src/Gallery/ImagePreview.tsx
@@ -176,7 +176,7 @@ export const ImagePreview: React.FC<ImagePreviewProps> = ({
                   <div className={styles.metadataItem}>
                     <span className={styles.metadataLabel}>ev</span>
                     <span className={styles.metadataValue}>
-                      {image.metadata.ev}onClick
+                      {image.metadata.ev}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- remove stray text in `ImagePreview`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1c5c9bbc83269b0cdd8a2b1a92c5