### PR TITLE
Fix gallery metadata display

### DIFF
--- a/src/Gallery/ImagePreview.tsx
+++ b/src/Gallery/ImagePreview.tsx
@@ -148,14 +148,6 @@ export const ImagePreview: React.FC<ImagePreviewProps> = ({
                     </span>
                   </div>
                 )}
-                {image.metadata.time && (
-                  <div className={styles.metadataItem}>
-                    <span className={styles.metadataLabel}>Date</span>
-                    <span className={styles.metadataValue}>
-                      {image.metadata.time}
-                    </span>
-                  </div>
-                )}
                 {image.metadata.camera && (
                   <div className={styles.metadataItem}>
                     <span className={styles.metadataLabel}>Camera</span>
@@ -176,7 +168,7 @@ export const ImagePreview: React.FC<ImagePreviewProps> = ({
                   <div className={styles.metadataItem}>
                     <span className={styles.metadataLabel}>ev</span>
                     <span className={styles.metadataValue}>
-                      {image.metadata.ev}onClick
+                      {image.metadata.ev}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- clean up ImagePreview component metadata section

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1463003c8326ad140e58fc7ed5ee